### PR TITLE
Change Context::define to Context.define

### DIFF
--- a/Examples/Dijkstra/CalculateShortestDistance.rb
+++ b/Examples/Dijkstra/CalculateShortestDistance.rb
@@ -1,4 +1,4 @@
-Context::define :CalculateShortestDistance do
+Contetx.define :CalculateShortestDistance do
 
   role :tentative_distance_values do
   end

--- a/Examples/Dijkstra/CalculateShortestDistance.rb
+++ b/Examples/Dijkstra/CalculateShortestDistance.rb
@@ -1,4 +1,4 @@
-Contetx.define :CalculateShortestDistance do
+Context.define :CalculateShortestDistance do
 
   role :tentative_distance_values do
   end

--- a/Examples/Dijkstra/calculate_shortest_path.rb
+++ b/Examples/Dijkstra/calculate_shortest_path.rb
@@ -38,7 +38,7 @@
 #
 # Map is a DCI role. The role in this example is played by an
 # object representing a particular Manhattan geometry
-ctx, source = Context::define :CalculateShortestPath do
+ctx, source = Contetx.define :CalculateShortestPath do
   role :distance_labeled_graph_node do
     # Access to roles and other Context data
     tentative_distance_values do

--- a/Examples/Dijkstra/calculate_shortest_path.rb
+++ b/Examples/Dijkstra/calculate_shortest_path.rb
@@ -38,7 +38,7 @@
 #
 # Map is a DCI role. The role in this example is played by an
 # object representing a particular Manhattan geometry
-ctx, source = Contetx.define :CalculateShortestPath do
+ctx, source = Context.define :CalculateShortestPath do
   role :distance_labeled_graph_node do
     # Access to roles and other Context data
     tentative_distance_values do

--- a/Examples/MoneyTransfer.rb
+++ b/Examples/MoneyTransfer.rb
@@ -1,6 +1,6 @@
 require './lib/maroon.rb'
 
-Context::define :MoneyTransfer do
+Contetx.define :MoneyTransfer do
   role :source do
     withdraw do |amount|
       source.movement(amount)

--- a/Examples/MoneyTransfer.rb
+++ b/Examples/MoneyTransfer.rb
@@ -1,6 +1,6 @@
 require './lib/maroon.rb'
 
-Contetx.define :MoneyTransfer do
+Context.define :MoneyTransfer do
   role :source do
     withdraw do |amount|
       source.movement(amount)

--- a/Examples/greeter.rb
+++ b/Examples/greeter.rb
@@ -8,7 +8,7 @@ class Person
   attr_accessor :greeting
 end
 
-ctx, source = Context::define :Greet_Someone, :greet do
+ctx, source = Contetx.define :Greet_Someone, :greet do
   role :greeter do
     welcome do
       self.greeting

--- a/Examples/greeter.rb
+++ b/Examples/greeter.rb
@@ -8,7 +8,7 @@ class Person
   attr_accessor :greeting
 end
 
-ctx, source = Contetx.define :Greet_Someone, :greet do
+ctx, source = Context.define :Greet_Someone, :greet do
   role :greeter do
     welcome do
       self.greeting

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the examples for detailed information on how to use maroon.
 
 Essentially you can define a context by using
 
-Context::define :context_name do
+Contetx.define :context_name do
    role :role_name do
       print_self do |x| #notice no symbol
          p "#{role_name} #use role_name to refer to the role of said name

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the examples for detailed information on how to use maroon.
 
 Essentially you can define a context by using
 
-Contetx.define :context_name do
+Context.define :context_name do
    role :role_name do
       print_self do |x| #notice no symbol
          p "#{role_name} #use role_name to refer to the role of said name

--- a/Test/Context_test.rb
+++ b/Test/Context_test.rb
@@ -11,7 +11,7 @@ class ContextTest < Test::Unit::TestCase
     name = :MyContextRoleMethodCall
     role_name = :rol
 
-    c=Context::define name do
+    c=Contetx.define name do
       role role_name do
         def rolem(x, y)
           x+y
@@ -29,7 +29,7 @@ class ContextTest < Test::Unit::TestCase
   def xtest_simple
     name = :MyContextSimple
     role_name = :r
-    Context::define name do
+    Contetx.define name do
       role role_name do
       end
     end
@@ -39,7 +39,7 @@ class ContextTest < Test::Unit::TestCase
   def xtest_bind
     name = :MyContextBind
 
-    c= Context::define name do
+    c= Contetx.define name do
       role :role_name do
         def sum
           @sum += role_name
@@ -61,7 +61,7 @@ class ContextTest < Test::Unit::TestCase
   def xtest_role_method
     name = :MyContext
     role_name = :rol
-    Context::define name do
+    Contetx.define name do
       role role_name do
         def rolem
           0+1
@@ -74,7 +74,7 @@ class ContextTest < Test::Unit::TestCase
   def xtest_role_method_args
     name = :MyContextArgs
     role_name = :rol
-    Context::define name do
+    Contetx.define name do
       role role_name do
         def rolem(x, y)
           x+y
@@ -87,7 +87,7 @@ class ContextTest < Test::Unit::TestCase
   def xtest_role_method_splat
     name = :MyContextSplat
     role_name = :rol
-    Context::define name do
+    Contetx.define name do
       role role_name do
         def rolem(x, *args)
           x+(args[0])
@@ -100,7 +100,7 @@ class ContextTest < Test::Unit::TestCase
   def xtest_role_method_block
     name = :MyContextBlock
     role_name = :rol
-    c= Context::define name do
+    c= Contetx.define name do
       role :num do
         def next
           num + 3
@@ -124,7 +124,7 @@ class ContextTest < Test::Unit::TestCase
   def xtest_class_method_block
     name = :MyContextClass
     role_name = :rol
-    Context::define name do
+    Contetx.define name do
       role :dummy do end
       role role_name do
         def rolem(*args, &b)

--- a/Test/Context_test.rb
+++ b/Test/Context_test.rb
@@ -11,7 +11,7 @@ class ContextTest < Test::Unit::TestCase
     name = :MyContextRoleMethodCall
     role_name = :rol
 
-    c=Contetx.define name do
+    c=Context.define name do
       role role_name do
         def rolem(x, y)
           x+y
@@ -29,7 +29,7 @@ class ContextTest < Test::Unit::TestCase
   def xtest_simple
     name = :MyContextSimple
     role_name = :r
-    Contetx.define name do
+    Context.define name do
       role role_name do
       end
     end
@@ -39,7 +39,7 @@ class ContextTest < Test::Unit::TestCase
   def xtest_bind
     name = :MyContextBind
 
-    c= Contetx.define name do
+    c= Context.define name do
       role :role_name do
         def sum
           @sum += role_name
@@ -61,7 +61,7 @@ class ContextTest < Test::Unit::TestCase
   def xtest_role_method
     name = :MyContext
     role_name = :rol
-    Contetx.define name do
+    Context.define name do
       role role_name do
         def rolem
           0+1
@@ -74,7 +74,7 @@ class ContextTest < Test::Unit::TestCase
   def xtest_role_method_args
     name = :MyContextArgs
     role_name = :rol
-    Contetx.define name do
+    Context.define name do
       role role_name do
         def rolem(x, y)
           x+y
@@ -87,7 +87,7 @@ class ContextTest < Test::Unit::TestCase
   def xtest_role_method_splat
     name = :MyContextSplat
     role_name = :rol
-    Contetx.define name do
+    Context.define name do
       role role_name do
         def rolem(x, *args)
           x+(args[0])
@@ -100,7 +100,7 @@ class ContextTest < Test::Unit::TestCase
   def xtest_role_method_block
     name = :MyContextBlock
     role_name = :rol
-    c= Contetx.define name do
+    c= Context.define name do
       role :num do
         def next
           num + 3
@@ -124,7 +124,7 @@ class ContextTest < Test::Unit::TestCase
   def xtest_class_method_block
     name = :MyContextClass
     role_name = :rol
-    Contetx.define name do
+    Context.define name do
       role :dummy do end
       role role_name do
         def rolem(*args, &b)

--- a/Test/Greeter_test_disabled.rb
+++ b/Test/Greeter_test_disabled.rb
@@ -12,7 +12,7 @@ class BasicTests < MiniTest::Unit::TestCase
 
   def test_define_context
     name = :MyContext
-    ctx, source = Context::define name do
+    ctx, source = Contetx.define name do
     end
     assert_equal(ctx.name, "Kernel::#{name}")
     assert_equal(source, "class #{name}\r\n\n\n  private\n\n\n\r\nend")
@@ -32,7 +32,7 @@ class BasicTests < MiniTest::Unit::TestCase
 
   def test_define_role
     name, role_name = :MyContextWithRole, :my_role
-    ctx, source = Context::define name do
+    ctx, source = Contetx.define name do
       role role_name do
         role_go_do do
 
@@ -46,7 +46,7 @@ class BasicTests < MiniTest::Unit::TestCase
 
   def test_args_on_role_method
     name, role_name = :MyContextWithRoleAndArgs, :my_role
-    ctx, source = Context::define name do
+    ctx, source = Contetx.define name do
       role role_name do
         role_go_do do |x, y|
 
@@ -63,7 +63,7 @@ class BasicTests < MiniTest::Unit::TestCase
 
   def test_bind
     name, other_name = :MyContextUsingBind, :other_role
-    ctx, source = Context::define name do
+    ctx, source = Contetx.define name do
       role other_name do
         plus_one do
           (self + 1)

--- a/Test/Greeter_test_disabled.rb
+++ b/Test/Greeter_test_disabled.rb
@@ -12,7 +12,7 @@ class BasicTests < MiniTest::Unit::TestCase
 
   def test_define_context
     name = :MyContext
-    ctx, source = Contetx.define name do
+    ctx, source = Context.define name do
     end
     assert_equal(ctx.name, "Kernel::#{name}")
     assert_equal(source, "class #{name}\r\n\n\n  private\n\n\n\r\nend")
@@ -32,7 +32,7 @@ class BasicTests < MiniTest::Unit::TestCase
 
   def test_define_role
     name, role_name = :MyContextWithRole, :my_role
-    ctx, source = Contetx.define name do
+    ctx, source = Context.define name do
       role role_name do
         role_go_do do
 
@@ -46,7 +46,7 @@ class BasicTests < MiniTest::Unit::TestCase
 
   def test_args_on_role_method
     name, role_name = :MyContextWithRoleAndArgs, :my_role
-    ctx, source = Contetx.define name do
+    ctx, source = Context.define name do
       role role_name do
         role_go_do do |x, y|
 
@@ -63,7 +63,7 @@ class BasicTests < MiniTest::Unit::TestCase
 
   def test_bind
     name, other_name = :MyContextUsingBind, :other_role
-    ctx, source = Contetx.define name do
+    ctx, source = Context.define name do
       role other_name do
         plus_one do
           (self + 1)

--- a/base/maroon_base.rb
+++ b/base/maroon_base.rb
@@ -10,7 +10,7 @@
 # With in the block supplied to the role method you can define role methods the same way as you define interactions. See the method who
 # in the below example
 # = Example
-#    Context::define :Greeter do
+#    Contetx.define :Greeter do
 #        role :who do
 #          say do
 #            @who #could be self as well to refer to the current role player of the 'who' role

--- a/base/maroon_base.rb
+++ b/base/maroon_base.rb
@@ -10,7 +10,7 @@
 # With in the block supplied to the role method you can define role methods the same way as you define interactions. See the method who
 # in the below example
 # = Example
-#    Contetx.define :Greeter do
+#    Context.define :Greeter do
 #        role :who do
 #          say do
 #            @who #could be self as well to refer to the current role player of the 'who' role

--- a/lib/maroon/kernel.rb
+++ b/lib/maroon/kernel.rb
@@ -2,6 +2,6 @@ require_relative '../Context'
 
 unless Kernel::methods.detect { |m| m== :context }
   def context(*args, &b)
-    Context::define *args, &b
+    Contetx.define *args, &b
   end
 end

--- a/lib/maroon/kernel.rb
+++ b/lib/maroon/kernel.rb
@@ -2,6 +2,6 @@ require_relative '../Context'
 
 unless Kernel::methods.detect { |m| m== :context }
   def context(*args, &b)
-    Contetx.define *args, &b
+    Context.define *args, &b
   end
 end


### PR DESCRIPTION
There has be some discussion about removing the double-colon method call from future versions of Ruby. 
