### PR TITLE
Alteration to variable scoping and minor changes to accessor methods

### DIFF
--- a/base/ImmutableStack.rb
+++ b/base/ImmutableStack.rb
@@ -13,7 +13,7 @@ context :ImmutableStack do
   end
 
   def self.empty
-    @@empty ||= self.new(nil, nil)
+    @empty ||= self.new(nil, nil)
   end
 
   def each

--- a/base/immutable_queue.rb
+++ b/base/immutable_queue.rb
@@ -27,7 +27,7 @@ context :ImmutableQueue do
   end
 
   def self.empty
-    @@empty ||= ImmutableQueue.new(ImmutableStack::empty, ImmutableStack::empty)
+    @empty ||= ImmutableQueue.new(ImmutableStack::empty, ImmutableStack::empty)
   end
 
   def push_array(arr)

--- a/base/maroon_base.rb
+++ b/base/maroon_base.rb
@@ -45,16 +45,16 @@ c = context :Context do
     if base_class and ((not default_interaction) and (not base_class.instance_of?(Class))) then
       base_class, default_interaction = default_interaction, base_class
     end
-    @@with_contracts ||= nil
-    @@generate_file_path ||= nil
+    @with_contracts ||= nil
+    @generate_file_path ||= nil
     ctx = self.send(:create_context_factory,  name, base_class, default_interaction, block)
     transformer = Transformer.new name, ctx.roles,ctx.interactions,ctx.private_interactions,base_class, default_interaction
-    return transformer.transform @@generate_file_path, @@with_contracts
+    return transformer.transform @generate_file_path, @with_contracts
   end
 
   def self.generate_files_in(*args, &b)
 
-    @@generate_file_path = args[0]
+    @generate_file_path = args[0]
 
   end
 
@@ -116,12 +116,12 @@ c = context :Context do
   end
 
   def self.with_contracts(*args)
-    return @@with_contracts if (args.length == 0)
+    return @with_contracts if (args.length == 0)
     value = args[0]
-    if @@with_contracts and (not value) then
+    if @with_contracts and (not value) then
       raise('make up your mind! disabling contracts during execution will result in undefined behavior')
     end
-    @@with_contracts = value
+    @with_contracts = value
 
   end
 

--- a/base/transfomer.rb
+++ b/base/transfomer.rb
@@ -164,10 +164,10 @@ def self.refute_that(obj)
   ContextAsserter.new(self.contracts,obj,false)
 end
 def self.contracts
-  @@contracts
+  @contracts
 end
 def self.contracts=(value)
-  @@contracts = value
+  @contracts = value
 end')
         c.contracts = contracts
       end

--- a/generated/Tokens.rb
+++ b/generated/Tokens.rb
@@ -1,6 +1,11 @@
 class Tokens
   def self.define_token(name)
-    class_eval("@@#{name} = Tokens.new :#{name};def Tokens.#{name};@@#{name};end")
+    class_eval %{
+      @#{name} = Tokens.new :#{name};
+      def Tokens.#{name}
+        @#{name}
+      end
+    }
   end
 
   def to_s

--- a/lib/Context.rb
+++ b/lib/Context.rb
@@ -117,8 +117,6 @@ class Context
     @default_interaction = default_interaction
   end
 
-  attr_reader :name
-  attr_reader :base_class
-  attr_reader :default_interaction
+  attr_reader :name, :base_class, :default_interaction
 
 end

--- a/lib/Context.rb
+++ b/lib/Context.rb
@@ -1,6 +1,7 @@
 class Context
   def self.define(*args, &block)
     name, base_class, default_interaction = *args
+
     if default_interaction and (not base_class.instance_of?(Class)) then
       base_class = eval(base_class.to_s)
     end
@@ -18,17 +19,7 @@ class Context
     @@generate_file_path = args[0]
   end
 
-  def roles()
-    @roles
-  end
-
-  def interactions()
-    @interactions
-  end
-
-  def private_interactions()
-    @private_interactions
-  end
+  attr_reader :roles, :interactions, :private_interactions
 
   private
   def get_definitions(b)

--- a/lib/Context.rb
+++ b/lib/Context.rb
@@ -8,15 +8,15 @@ class Context
     if base_class and ((not default_interaction) and (not base_class.instance_of?(Class))) then
       base_class, default_interaction = default_interaction, base_class
     end
-    @@with_contracts ||= nil
-    @@generate_file_path ||= nil
+    @with_contracts ||= nil
+    @generate_file_path ||= nil
     ctx = self.send(:create_context_factory, name, base_class, default_interaction, block)
     transformer = Transformer.new(name, ctx.roles, ctx.interactions, ctx.private_interactions, base_class, default_interaction)
-    return transformer.transform(@@generate_file_path, @@with_contracts)
+    return transformer.transform(@generate_file_path, @with_contracts)
   end
 
   def self.generate_files_in(*args, &b)
-    @@generate_file_path = args[0]
+    @generate_file_path = args[0]
   end
 
   attr_reader :roles, :interactions, :private_interactions
@@ -59,12 +59,12 @@ class Context
   end
 
   def self.with_contracts(*args)
-    return @@with_contracts if (args.length == 0)
+    return @with_contracts if (args.length == 0)
     value = args[0]
-    if @@with_contracts and (not value) then
+    if @with_contracts and (not value) then
       raise("make up your mind! disabling contracts during execution will result in undefined behavior")
     end
-    @@with_contracts = value
+    @with_contracts = value
   end
 
   def is_definition?(exp)

--- a/lib/ImmutableQueue.rb
+++ b/lib/ImmutableQueue.rb
@@ -21,7 +21,7 @@ class ImmutableQueue
   end
 
   def self.empty()
-    @@empty ||= ImmutableQueue.new(ImmutableStack.empty, ImmutableStack.empty)
+    @empty ||= ImmutableQueue.new(ImmutableStack.empty, ImmutableStack.empty)
   end
 
   def push_array(arr)

--- a/lib/ImmutableStack.rb
+++ b/lib/ImmutableStack.rb
@@ -8,7 +8,7 @@ class ImmutableStack
   end
 
   def self.empty()
-    @@empty ||= self.new(nil, nil)
+    @empty ||= self.new(nil, nil)
   end
 
   def each()

--- a/lib/Tokens.rb
+++ b/lib/Tokens.rb
@@ -1,6 +1,11 @@
 class Tokens
   def self.define_token(name)
-    class_eval("@@#{name} = Tokens.new :#{name};def Tokens.#{name};@@#{name};end")
+    class_eval %{
+      @#{name} = Tokens.new :#{name};
+      def Tokens.#{name}
+        @#{name}
+      end
+    }
   end
 
   def to_s

--- a/lib/Transformer.rb
+++ b/lib/Transformer.rb
@@ -21,7 +21,7 @@ class Transformer
     else
       c = @base_class ? (Class.new(base_class)) : (Class.new)
       if with_contracts then
-        c.class_eval("def self.assert_that(obj)\n  ContextAsserter.new(self.contracts,obj)\nend\ndef self.refute_that(obj)\n  ContextAsserter.new(self.contracts,obj,false)\nend\ndef self.contracts\n  @@contracts\nend\ndef self.contracts=(value)\n  @@contracts = value\nend")
+        c.class_eval("def self.assert_that(obj)\n  ContextAsserter.new(self.contracts,obj)\nend\ndef self.refute_that(obj)\n  ContextAsserter.new(self.contracts,obj,false)\nend\ndef self.contracts\n  @contracts\nend\ndef self.contracts=(value)\n  @contracts = value\nend")
         c.contracts = contracts
       end
       Kernel.const_set(context_name, c)


### PR DESCRIPTION
Class variables such as `@@some_var` are set in one class, but subclasses can change that value. In other words, superclasses and subclasses share class variables. Ruby can use instance variables on the class level and those are scoped to the individual class.

This requests makes a change to remove class variables and replace them with instance variables on the class.

Additionally, some simple methods were made `attr_accessor`.
