### PR TITLE
minor format change for the code sample in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ See the examples for detailed information on how to use maroon.
 
 Essentially you can define a context by using
 
+```ruby
 Context.define :context_name do
    role :role_name do
       print_self do |x| #notice no symbol
@@ -29,6 +30,7 @@ Context.define :context_name do
       end
    end
 end
+```
 
 ## Running Tests
 


### PR DESCRIPTION
Some sample code in the README wasn't formatted properly for display. This is a minor fix to address that.
